### PR TITLE
PKG-7813: flask-compress 1.17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,36 @@
 {% set name = "Flask-Compress" %}
-{% set version = "1.13" %}
-{% set sha256 = "ee96f18bf9b00f2deb4e3406ca4a05093aa80e2ef0578525a3b4d32ecdff129d" %}
+{% set version = "1.17" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 1ebb112b129ea7c9e7d6ee6d5cc0d64f226cbc50c4daddf1a58b9bd02253fbd8
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: True # [py<37]
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<39]
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
-    - setuptools_scm
+    - setuptools >=42
+    - setuptools_scm <8
     - toml
     - wheel
   run:
     - python
     - flask
-    - brotli-python
+    - brotli-python # [python_impl != "pypy"]
+    - brotlicffi  # [python_impl == "pypy"]
+    - zstandard
+    - cffi >=1.17  # [python_impl == "pypy"]
 
 test:
   source_files:
@@ -37,8 +40,10 @@ test:
   requires:
     - pip
     - pytest
+    - flask-caching
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest tests
 
 about:
@@ -46,9 +51,12 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
-  summary: Compress responses in your Flask app with gzip.
+  summary: Flask-Compress allows you to easily compress your Flask application's responses with gzip, deflate, brotli or zstd.
   description: |
-    Flask-Compress allows you to easily compress your Flask application's responses with gzip.
+    Flask-Compress allows you to easily compress your Flask application's responses with gzip, deflate, brotli or zstd. 
+    It originally started as a fork of Flask-gzip. Supported Python versions are 3.9 and newer.
+    The preferred solution is to have a server (like Nginx) automatically compress the static files for you. 
+    If you don't have that option Flask-Compress will solve the problem for you.
   dev_url: https://github.com/colour-science/flask-compress
   doc_url: https://github.com/colour-science/flask-compress/blob/master/README.md
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,8 @@ test:
     - pip
     - pytest
     - flask-caching
+    # AttributeError: module 'werkzeug' has no attribute '__version__'
+    - werkzeug <3.1.3
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   run:
     - python
     - flask
-    - brotli-python # [python_impl != "pypy"]
+    - brotli-python  # [python_impl != "pypy"]
     - brotlicffi  # [python_impl == "pypy"]
     - zstandard
     - cffi >=1.17  # [python_impl == "pypy"]


### PR DESCRIPTION
flask-compress 1.17

**Destination channel:** defaults

### Links
- [PKG-7813](https://anaconda.atlassian.net/browse/PKG-7813) 
- dev_url: https://github.com/colour-science/flask-compress/tree/v1.17
- conda_forge: https://github.com/conda-forge/flask-compress-feedstock
- pypi: https://pypi.org/project/flask-compress/1.17
- pypi inspector: https://inspector.pypi.io/project/flask-compress/1.17

### Explanation of changes:
- bump version

[PKG-7813]: https://anaconda.atlassian.net/browse/PKG-7813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ